### PR TITLE
Adds tests for Unit struct

### DIFF
--- a/src/expr/unit.rs
+++ b/src/expr/unit.rs
@@ -311,49 +311,6 @@ impl std::fmt::Display for Unit {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_disp() {
-        let u: Unit = BaseUnit::Meter.into();
-        assert_eq!(format!("{}", u).as_str(), "m");
-
-        let desc = UnitDesc::Base([
-            Ratio::one(),
-            Ratio::one(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-        ]);
-        let u = Unit {
-            desc,
-            exp: 0,
-            mult: 1.0,
-        };
-        assert_eq!(format!("{}", u).as_str(), "m g");
-
-        let desc = UnitDesc::Base([
-            Ratio::one(),
-            Ratio::one() * 2,
-            -Ratio::one(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-        ]);
-        let u = Unit {
-            desc,
-            exp: 0,
-            mult: 1.0,
-        };
-        assert_eq!(format!("{}", u).as_str(), "m g^2 s^-1");
-    }
-}
-
 impl std::ops::Mul for Unit {
     type Output = Unit;
 
@@ -397,5 +354,48 @@ impl std::ops::Div for Unit {
             }
             _ => todo!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_disp() {
+        let u: Unit = BaseUnit::Meter.into();
+        assert_eq!(format!("{}", u).as_str(), "m");
+
+        let desc = UnitDesc::Base([
+            Ratio::one(),
+            Ratio::one(),
+            Ratio::zero(),
+            Ratio::zero(),
+            Ratio::zero(),
+            Ratio::zero(),
+            Ratio::zero(),
+        ]);
+        let u = Unit {
+            desc,
+            exp: 0,
+            mult: rug::Rational::from_f32(1.0).unwrap(),
+        };
+        assert_eq!(format!("{}", u).as_str(), "m g");
+
+        let desc = UnitDesc::Base([
+            Ratio::one(),
+            Ratio::one() * 2,
+            -Ratio::one(),
+            Ratio::zero(),
+            Ratio::zero(),
+            Ratio::zero(),
+            Ratio::zero(),
+        ]);
+        let u = Unit {
+            desc,
+            exp: 0,
+            mult: rug::Rational::from_f32(1.0).unwrap(),
+        };
+        assert_eq!(format!("{}", u).as_str(), "m g^2 s^-1");
     }
 }

--- a/src/expr/unit.rs
+++ b/src/expr/unit.rs
@@ -136,11 +136,6 @@ impl Unit {
         (0..rhs - 1).for_each(|_| ret = ret.clone() * self.clone());
         ret
     }
-
-    pub fn test(&self) {
-        println!("Unit {{\nexp = {}\nmult={}\n}}",
-            self.exp,self.mult);
-    }
 }
 
 impl PartialEq for Unit {

--- a/src/expr/unit.rs
+++ b/src/expr/unit.rs
@@ -136,6 +136,11 @@ impl Unit {
         (0..rhs - 1).for_each(|_| ret = ret.clone() * self.clone());
         ret
     }
+
+    pub fn test(&self) {
+        println!("Unit {{\nexp = {}\nmult={}\n}}",
+            self.exp,self.mult);
+    }
 }
 
 impl PartialEq for Unit {
@@ -360,42 +365,271 @@ impl std::ops::Div for Unit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
 
     #[test]
-    fn test_disp() {
-        let u: Unit = BaseUnit::Meter.into();
-        assert_eq!(format!("{}", u).as_str(), "m");
+    fn to_string_base_unit(){
+        assert_eq!(&BaseUnit::Meter.to_string(),"m");
+        assert_eq!(&BaseUnit::Gram.to_string(),"g");
+        assert_eq!(&BaseUnit::Second.to_string(),"s");
+        assert_eq!(&BaseUnit::Ampere.to_string(),"A");
+        assert_eq!(&BaseUnit::Kelvin.to_string(),"K");
+        assert_eq!(&BaseUnit::Mole.to_string(),"M");
+        assert_eq!(&BaseUnit::Candela.to_string(),"cd");
+    }
 
-        let desc = UnitDesc::Base([
-            Ratio::one(),
-            Ratio::one(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-        ]);
-        let u = Unit {
-            desc,
-            exp: 0,
-            mult: rug::Rational::from_f32(1.0).unwrap(),
-        };
-        assert_eq!(format!("{}", u).as_str(), "m g");
+    #[test]
+    fn empty_unit(){
+        let unit = Unit::empty();
+        assert_eq!(unit.to_string(),"");
+    }
 
-        let desc = UnitDesc::Base([
-            Ratio::one(),
-            Ratio::one() * 2,
-            -Ratio::one(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-            Ratio::zero(),
-        ]);
-        let u = Unit {
-            desc,
-            exp: 0,
-            mult: rug::Rational::from_f32(1.0).unwrap(),
-        };
-        assert_eq!(format!("{}", u).as_str(), "m g^2 s^-1");
+    #[test]
+    fn pow_unit_meter(){
+        let unit = Unit::from(BaseUnit::Meter).pow(3);
+        assert_eq!(unit.to_string(),"m^3");
+    }
+
+    #[test]
+    fn pow_unit_gram(){
+        let unit = Unit::from(BaseUnit::Gram).pow(3);
+        assert_eq!(unit.to_string(),"g^3");
+    }
+
+    #[test]
+    fn pow_unit_second(){
+        let unit = Unit::from(BaseUnit::Second).pow(3);
+        assert_eq!(unit.to_string(),"s^3");
+    }
+
+    #[test]
+    fn pow_unit_ampere(){
+        let unit = Unit::from(BaseUnit::Ampere).pow(3);
+        assert_eq!(unit.to_string(),"A^3");
+    }
+
+    #[test]
+    fn pow_unit_kelvin(){
+        let unit = Unit::from(BaseUnit::Kelvin).pow(3);
+        assert_eq!(unit.to_string(),"K^3");
+    }
+
+    #[test]
+    fn pow_unit_mole(){
+        let unit = Unit::from(BaseUnit::Mole).pow(3);
+        assert_eq!(unit.to_string(),"M^3");
+    }
+
+    #[test]
+    fn pow_unit_candela(){
+        let unit = Unit::from(BaseUnit::Candela).pow(3);
+        assert_eq!(unit.to_string(),"cd^3");
+    }
+
+    #[test]
+    fn partial_eq_unit_base_success(){
+        let unit1 = Unit::from(BaseUnit::Meter);
+        let unit2 = Unit::from(BaseUnit::Meter);
+        assert_eq!(unit1,unit2);
+    }
+
+    #[test]
+    fn partial_eq_unit_base_failure(){
+        let unit1 = Unit::from(BaseUnit::Meter);
+        let unit2 = Unit::from(BaseUnit::Ampere);
+        assert_ne!(unit1,unit2);
+    }
+
+    #[test]
+    fn partial_eq_unit_pow_success(){
+        let unit1 = Unit::from(BaseUnit::Meter).pow(3);
+        let unit2 = Unit::from(BaseUnit::Meter).pow(3);
+        assert_eq!(unit1,unit2);
+    }
+
+    #[test]
+    fn partial_eq_unit_pow_failure(){
+        let unit1 = Unit::from(BaseUnit::Meter).pow(2);
+        let unit2 = Unit::from(BaseUnit::Meter).pow(3);
+        assert_ne!(unit1,unit2);
+    }
+
+    #[test]
+    fn try_from_unit_meter(){
+        let unit = Unit::try_from("meter").unwrap();
+        assert_eq!(unit.to_string(),"m");
+    }
+
+    #[test]
+    fn try_from_unit_gram(){
+        let unit = Unit::try_from("gram").unwrap();
+        assert_eq!(unit.to_string(),"g");
+    }
+
+    #[test]
+    fn try_from_unit_second(){
+        let unit = Unit::try_from("second").unwrap();
+        assert_eq!(unit.to_string(),"s");
+    }
+
+    #[test]
+    fn try_from_unit_ampere(){
+        let unit = Unit::try_from("ampere").unwrap();
+        assert_eq!(unit.to_string(),"A");
+    }
+
+    #[test]
+    fn try_from_unit_mole(){
+        let unit = Unit::try_from("mole").unwrap();
+        assert_eq!(unit.to_string(),"M");
+    }
+
+    #[test]
+    fn try_from_unit_joule(){
+        let unit1 = Unit::try_from("joule").unwrap();
+        assert_eq!(unit1.to_string(),"m^2 g s^-2");
+
+        let unit2 = Unit::try_from("J").unwrap();
+        assert_eq!(unit2.to_string(),"m^2 g s^-2");
+    }
+
+    #[test]
+    fn try_from_unit_newton(){
+        let unit1 = Unit::try_from("newton").unwrap();
+        assert_eq!(unit1.to_string(),"m g s^-2");
+
+        let unit2 = Unit::try_from("N").unwrap();
+        assert_eq!(unit2.to_string(),"m g s^-2");
+    }
+
+    #[test]
+    fn try_from_unit_minute(){
+        let unit1 = Unit::try_from("minute").unwrap();
+        assert_eq!(unit1.to_string(),"s");
+
+        let unit2 = Unit::try_from("min").unwrap();
+        assert_eq!(unit2.to_string(),"s");
+    }
+
+    #[test]
+    fn try_from_unit_hour(){
+        let unit1 = Unit::try_from("hour").unwrap();
+        assert_eq!(unit1.to_string(),"s");
+
+        let unit2 = Unit::try_from("hours").unwrap();
+        assert_eq!(unit2.to_string(),"s");
+    }
+
+    #[test]
+    fn try_from_unit_day(){
+        let unit1 = Unit::try_from("day").unwrap();
+        assert_eq!(unit1.to_string(),"s");
+
+        let unit2 = Unit::try_from("days").unwrap();
+        assert_eq!(unit2.to_string(),"s");
+    }
+
+    #[test]
+    fn try_from_unit_year(){
+        let unit1 = Unit::try_from("year").unwrap();
+        assert_eq!(unit1.to_string(),"s");
+
+        let unit2 = Unit::try_from("years").unwrap();
+        assert_eq!(unit2.to_string(),"s");
+    }
+
+    #[test]
+    fn mult_meter(){
+        let unit = Unit::try_from("meters").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"m^2");
+    }
+
+    #[test]
+    fn mult_gram(){
+        let unit = Unit::try_from("grams").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"g^2");
+    }
+
+    #[test]
+    fn mult_meters_grams() {
+        let meters = Unit::try_from("meters").unwrap();
+        let grams  = Unit::try_from("grams").unwrap();
+        let result = (meters * grams).to_string();
+        assert_eq!(result, "m g");
+    }
+
+    #[test]
+    fn mult_second(){
+        let unit = Unit::try_from("seconds").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"s^2");
+    }
+
+    #[test]
+    fn mult_ampere(){
+        let unit = Unit::try_from("amperes").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"A^2");
+    }
+
+    #[test]
+    fn mult_ampere_second() {
+        let amperes = Unit::try_from("amperes").unwrap();
+        let second  = Unit::try_from("second").unwrap();
+        let result = (amperes * second).to_string();
+        assert_eq!(result, "s A");
+    }
+
+    #[test]
+    fn mult_mole(){
+        let unit = Unit::try_from("moles").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"M^2");
+    }
+
+    #[test]
+    fn mult_joule(){
+        let unit = Unit::try_from("joule").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"m^4 g^2 s^-4");
+    }
+
+    #[test]
+    fn mult_joule_second() {
+        let joules = Unit::try_from("joule").unwrap();
+        let second  = Unit::try_from("second").unwrap();
+        let result = (joules * second).to_string();
+        assert_eq!(result, "m^2 g s^-1");
+    }
+
+    #[test]
+    fn mult_newton(){
+        let unit = Unit::try_from("newton").unwrap();
+        let out  = (unit.clone() * unit).to_string();
+        assert_eq!(out,"m^2 g^2 s^-4");
+    }
+
+    #[test]
+    fn div_meter(){
+        let mut unit1 = Unit::try_from("meters").unwrap();
+        unit1.exp = 4;
+
+        let mut unit2 = Unit::try_from("meters").unwrap();
+        unit2.exp = 2;
+
+        // TODO: Should this pass?
+        // let out  = (unit1 / unit2).to_string();
+        // assert_eq!(out,"m^2");
+    }
+
+    #[test]
+    fn div_meter_cancellation(){
+        let unit = Unit::try_from("meters").unwrap();
+        let out  = (unit.clone() / unit).to_string();
+
+        // TODO: Should this pass?
+        // assert_eq!(out,"");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn test_basic() {
         assert_eq!(full_eval("5 - 3").to_string(), "2".to_string());
-        dbg!(full_eval("5 kg"));
+        // dbg!(full_eval("5 kg"));
         assert_eq!(full_eval("5 kg").to_string(), "5000 g".to_string());
         assert_eq!(full_eval("5 grams").to_string(), "5 g".to_string());
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ mod tests {
         );
         assert_eq!(
             full_eval("5 meters / 4 grams").to_string(),
-            "1.25 m g^-1".to_string()
+            "5/4 m g^-1".to_string()
         );
     }
 }


### PR DESCRIPTION
## Overview
Added a bunch of simple tests for Unit structs. A lot of them are pretty trivial, but I thought the obvious stuff should be covered. If these changes are accepted, you'll have to make sure they pass when you change Unit in the future.

## Blocking issues
There was some unexpected behavior when dividing-  you get empty output (`unit.to_string()` = "") for dividing meters^4 by meters^2, which should give "m^2" as the output unless I'm missing something. You get the same output when dividing two identical Unit instances, but that seems acceptable for identical numerator and denominator.

I left example tests (w/ commented assertions) for both of those cases. If you clarify what's intended and/or fix the behavior, I'll add tests for those cases as well.
